### PR TITLE
feat: Player Statusレイアウトを追加する

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "dependencies": {
     "@9c5s/node-tcnet": "link:../node-tcnet",
+    "svelte-dnd-action": "^0.9.69",
     "ws": "^8.18.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,9 @@ importers:
       '@9c5s/node-tcnet':
         specifier: link:../node-tcnet
         version: link:../node-tcnet
+      svelte-dnd-action:
+        specifier: ^0.9.69
+        version: 0.9.69(svelte@5.54.0)
       ws:
         specifier: ^8.18.0
         version: 8.19.0
@@ -1663,6 +1666,11 @@ packages:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
 
+  svelte-dnd-action@0.9.69:
+    resolution: {integrity: sha512-NAmSOH7htJoYraTQvr+q5whlIuVoq88vEuHr4NcFgscDRUxfWPPxgie2OoxepBCQCikrXZV4pqV86aun60wVyw==}
+    peerDependencies:
+      svelte: '>=3.23.0 || ^5.0.0-next.0'
+
   svelte-eslint-parser@1.6.0:
     resolution: {integrity: sha512-qoB1ehychT6OxEtQAqc/guSqLS20SlA53Uijl7x375s8nlUT0lb9ol/gzraEEatQwsyPTJo87s2CmKL9Xab+Uw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0, pnpm: 10.30.3}
@@ -3211,6 +3219,10 @@ snapshots:
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
+
+  svelte-dnd-action@0.9.69(svelte@5.54.0):
+    dependencies:
+      svelte: 5.54.0
 
   svelte-eslint-parser@1.6.0(svelte@5.54.0):
     dependencies:

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -5,6 +5,7 @@
   import Dashboard from "./components/Dashboard.svelte";
   import CardsLayout from "./components/CardsLayout.svelte";
   import TableLayout from "./components/TableLayout.svelte";
+  import PlayerStatusLayout from "./components/player-status/PlayerStatusLayout.svelte";
   import LayoutSwitcher from "./components/LayoutSwitcher.svelte";
 
   $effect(() => {
@@ -23,6 +24,8 @@
   <CardsLayout />
 {:else if store.layoutMode === "table"}
   <TableLayout />
+{:else if store.layoutMode === "player-status"}
+  <PlayerStatusLayout />
 {:else}
   <Dashboard />
 {/if}

--- a/src/components/LayoutSwitcher.svelte
+++ b/src/components/LayoutSwitcher.svelte
@@ -6,6 +6,7 @@
     { key: "detail", label: "Detail", icon: "\u25A3" },
     { key: "cards", label: "Cards", icon: "\u25A6" },
     { key: "table", label: "Table", icon: "\u2261" },
+    { key: "player-status", label: "Player", icon: "\u25B6" },
   ];
 
   const themes: { key: Theme; label: string; icon: string }[] = [

--- a/src/components/WaveformSvg.svelte
+++ b/src/components/WaveformSvg.svelte
@@ -1,14 +1,23 @@
 <script lang="ts">
-  import type { WaveformBar } from "$lib/types.js";
+  import type { CuePoint, WaveformBar } from "$lib/types.js";
+  import CueMarkerLayer from "./player-status/CueMarkerLayer.svelte";
 
   interface Props {
     bars: WaveformBar[] | null;
     currentPosition: number;
     trackLength: number;
     height?: number;
+    cues?: CuePoint[] | null;
     class?: string;
   }
-  let { bars, currentPosition, trackLength, height = 80, class: className = "" }: Props = $props();
+  let {
+    bars,
+    currentPosition,
+    trackLength,
+    height = 80,
+    cues = null,
+    class: className = "",
+  }: Props = $props();
 
   const VIEW_WIDTH = 400;
   let barWidth = $derived(bars && bars.length > 0 ? VIEW_WIDTH / bars.length : 0);
@@ -16,6 +25,9 @@
 </script>
 
 <div class="border-b border-base-content/20 px-2 py-1 {className}">
+  {#if cues && cues.length > 0}
+    <CueMarkerLayer {cues} trackLengthMs={trackLength} />
+  {/if}
   {#if bars && bars.length > 0}
     <svg
       viewBox="0 0 {VIEW_WIDTH} {height}"

--- a/src/components/player-status/CueMarkerLayer.svelte
+++ b/src/components/player-status/CueMarkerLayer.svelte
@@ -1,0 +1,60 @@
+<script lang="ts">
+  import type { CuePoint } from "$lib/types.js";
+
+  interface Props {
+    cues: CuePoint[] | null;
+    trackLengthMs: number;
+    windowLeftMs?: number;
+    windowMs?: number;
+    class?: string;
+  }
+  let {
+    cues,
+    trackLengthMs,
+    windowLeftMs = 0,
+    windowMs,
+    class: className = "",
+  }: Props = $props();
+
+  // windowMs未指定時は全曲表示 (フル波形用)
+  let effectiveWindowMs = $derived(windowMs ?? trackLengthMs);
+  let effectiveWindowLeft = $derived(windowMs == null ? 0 : windowLeftMs);
+
+  function leftPercent(timeMs: number): number | null {
+    if (effectiveWindowMs <= 0) return null;
+    const pct = ((timeMs - effectiveWindowLeft) / effectiveWindowMs) * 100;
+    if (pct < 0 || pct > 100) return null;
+    return pct;
+  }
+
+  // CuePoint.type の値: 0=HotCue, 1=MemoryCue (server/parsers/cue-data.ts 参照)
+  const TYPE_HOT_CUE = 0;
+  const TYPE_MEMORY_CUE = 1;
+</script>
+
+<div class="relative h-2.5 {className}">
+  {#if cues && cues.length > 0 && trackLengthMs > 0}
+    {#each cues as cue}
+      {@const pct = leftPercent(cue.inTime)}
+      {#if pct !== null}
+        {#if cue.type === TYPE_MEMORY_CUE}
+          <div
+            class="absolute top-0 size-0"
+            style:left="{pct}%"
+            style:transform="translateX(-50%)"
+            style:border-left="5px solid transparent"
+            style:border-right="5px solid transparent"
+            style:border-top="8px solid var(--color-error)"
+          ></div>
+        {:else if cue.type === TYPE_HOT_CUE}
+          <div
+            class="absolute top-0 size-2"
+            style:left="{pct}%"
+            style:transform="translateX(-50%)"
+            style:background-color="rgb({cue.color.r}, {cue.color.g}, {cue.color.b})"
+          ></div>
+        {/if}
+      {/if}
+    {/each}
+  {/if}
+</div>

--- a/src/components/player-status/PlayerCard.svelte
+++ b/src/components/player-status/PlayerCard.svelte
@@ -52,25 +52,24 @@
   let position = $derived(derivePlaybackPosition(time, metricsOk ? metrics : null));
 </script>
 
+<!--
+  ドラッグハンドルは PlayerHeader 部分のみに限定する。
+  波形領域やスライダー・ステータスバーで pointerdown しても dndzone が反応しないよう、
+  各セクションで stopPropagation する。
+-->
 <div
   data-testid="player-card"
   class="
-    card relative cursor-grab overflow-hidden rounded-xl border border-base-content/20 bg-base-100 shadow-xl
-    transition-colors
+    card relative overflow-hidden rounded-xl border border-base-content/20 bg-base-100 shadow-xl transition-colors
     hover:border-primary
   "
 >
-  <div
-    class="pointer-events-none absolute top-2.5 left-2.5 h-4 w-3 opacity-0 transition-opacity"
-    style:background-image="radial-gradient(circle, var(--color-base-content/40) 1px, transparent 1px)"
-    style:background-size="4px 6px"
-  ></div>
-
-  <div data-testid="player-header">
+  <div data-testid="player-header" class="cursor-grab" title="Drag here to reorder">
     <PlayerHeader {layer} {playerNumber} {metadata} {metrics} {artwork} {artworkFailed} />
   </div>
 
-  <div data-testid="player-zoom">
+  <!-- svelte-ignore a11y_no_static_element_interactions -->
+  <div data-testid="player-zoom" onpointerdown={(e) => e.stopPropagation()}>
     <WaveformCanvas
       bars={waveformBig}
       {cues}
@@ -82,11 +81,13 @@
     />
   </div>
 
-  <div data-testid="player-status-bar">
+  <!-- svelte-ignore a11y_no_static_element_interactions -->
+  <div data-testid="player-status-bar" onpointerdown={(e) => e.stopPropagation()}>
     <PlayerStatusBar {layer} {time} {metrics} />
   </div>
 
-  <div data-testid="player-full" class="px-5 pb-4">
+  <!-- svelte-ignore a11y_no_static_element_interactions -->
+  <div data-testid="player-full" class="px-5 pb-4" onpointerdown={(e) => e.stopPropagation()}>
     <span class="mb-1 block text-[9px] tracking-widest text-base-content/40 uppercase">Full Track</span>
     <WaveformSvg
       bars={waveformSmall}

--- a/src/components/player-status/PlayerCard.svelte
+++ b/src/components/player-status/PlayerCard.svelte
@@ -1,0 +1,99 @@
+<script lang="ts">
+  import type {
+    BeatGridEntry,
+    CuePoint,
+    LayerInfo,
+    MetadataData,
+    MetricsData,
+    TimeInfo,
+    WaveformBar,
+  } from "$lib/types.js";
+  import { derivePlaybackPosition } from "$lib/player-status/playback-position.js";
+  import { isMetricsConsistent } from "$lib/player-status/track-consistency.js";
+  import PlayerHeader from "./PlayerHeader.svelte";
+  import PlayerStatusBar from "./PlayerStatusBar.svelte";
+  import WaveformCanvas from "./WaveformCanvas.svelte";
+  import WaveformSvg from "../WaveformSvg.svelte";
+
+  interface Props {
+    layer: LayerInfo;
+    layerIndex: number;
+    playerNumber: number;
+    metadata: MetadataData | null;
+    metrics: MetricsData | null;
+    time: TimeInfo | null;
+    artwork: { base64: string; mimeType: string } | null;
+    artworkFailed: boolean;
+    waveformBig: WaveformBar[] | null;
+    waveformSmall: WaveformBar[] | null;
+    cues: CuePoint[] | null;
+    beatgrid: BeatGridEntry[] | null;
+    zoomScale: number;
+    onZoomChange: (v: number) => void;
+  }
+  let {
+    layer,
+    playerNumber,
+    metadata,
+    metrics,
+    time,
+    artwork,
+    artworkFailed,
+    waveformBig,
+    waveformSmall,
+    cues,
+    beatgrid,
+    zoomScale,
+    onZoomChange,
+  }: Props = $props();
+
+  // metrics 整合性を検査し、不整合なら derivePlaybackPosition へ null を渡す
+  let metricsOk = $derived(isMetricsConsistent(layer, metrics));
+  let position = $derived(derivePlaybackPosition(time, metricsOk ? metrics : null));
+</script>
+
+<div
+  data-testid="player-card"
+  class="
+    card relative cursor-grab overflow-hidden rounded-xl border border-base-content/20 bg-base-100 shadow-xl
+    transition-colors
+    hover:border-primary
+  "
+>
+  <div
+    class="pointer-events-none absolute top-2.5 left-2.5 h-4 w-3 opacity-0 transition-opacity"
+    style:background-image="radial-gradient(circle, var(--color-base-content/40) 1px, transparent 1px)"
+    style:background-size="4px 6px"
+  ></div>
+
+  <div data-testid="player-header">
+    <PlayerHeader {layer} {playerNumber} {metadata} {metrics} {artwork} {artworkFailed} />
+  </div>
+
+  <div data-testid="player-zoom">
+    <WaveformCanvas
+      bars={waveformBig}
+      {cues}
+      {beatgrid}
+      currentTimeMs={position.clampedElapsedMs}
+      trackLengthMs={position.trackLengthMs}
+      {zoomScale}
+      {onZoomChange}
+    />
+  </div>
+
+  <div data-testid="player-status-bar">
+    <PlayerStatusBar {layer} {time} {metrics} />
+  </div>
+
+  <div data-testid="player-full" class="px-5 pb-4">
+    <span class="mb-1 block text-[9px] tracking-widest text-base-content/40 uppercase">Full Track</span>
+    <WaveformSvg
+      bars={waveformSmall}
+      {cues}
+      currentPosition={position.clampedElapsedMs}
+      trackLength={position.trackLengthMs}
+      height={36}
+    />
+  </div>
+</div>

--- a/src/components/player-status/PlayerHeader.svelte
+++ b/src/components/player-status/PlayerHeader.svelte
@@ -1,0 +1,66 @@
+<script lang="ts">
+  import type { LayerInfo, MetadataData, MetricsData } from "$lib/types.js";
+  import { formatPosition } from "$lib/formatting.js";
+  import { isMetadataConsistent, isMetricsConsistent } from "$lib/player-status/track-consistency.js";
+  import ArtworkErrorIcon from "../ArtworkErrorIcon.svelte";
+
+  interface Props {
+    layer: LayerInfo;
+    playerNumber: number;
+    metadata: MetadataData | null;
+    metrics: MetricsData | null;
+    artwork: { base64: string; mimeType: string } | null;
+    artworkFailed: boolean;
+  }
+  let { layer, playerNumber, metadata, metrics, artwork, artworkFailed }: Props = $props();
+
+  let metaOk = $derived(isMetadataConsistent(layer, metadata));
+  let metricsOk = $derived(isMetricsConsistent(layer, metrics));
+  let boxColor = $derived(
+    layer.status === "PLAYING" || layer.status === "LOOPING"
+      ? "text-accent border-accent"
+      : "text-base-content/40 border-base-content/40",
+  );
+</script>
+
+<div class="grid grid-cols-[auto_1fr_auto] items-center gap-4 border-b border-base-content/20 p-4 pl-9">
+  <div class="avatar">
+    <div class="size-20 rounded-lg bg-linear-to-br from-primary to-secondary">
+      {#if artwork}
+        <img src="data:{artwork.mimeType};base64,{artwork.base64}" alt="artwork" />
+      {:else if artworkFailed}
+        <ArtworkErrorIcon />
+      {:else}
+        <div class="flex size-full items-center justify-center text-3xl text-base-100">♫</div>
+      {/if}
+    </div>
+  </div>
+
+  <div class="min-w-0">
+    <div class="truncate text-base font-semibold text-base-content">
+      {metaOk ? metadata!.trackTitle || "—" : "—"}
+    </div>
+    <div class="truncate text-sm text-primary">
+      {metaOk ? metadata!.trackArtist || "—" : "—"}
+    </div>
+    <div class="mt-1 flex flex-wrap gap-1.5">
+      {#if metaOk}
+        <span class="badge badge-ghost badge-sm">ID {metadata!.trackID}</span>
+      {/if}
+      {#if metricsOk && (metrics?.trackLength ?? 0) > 0}
+        <span class="badge badge-ghost badge-sm">{formatPosition(metrics!.trackLength!)}</span>
+      {/if}
+      {#if metaOk}
+        <span class="badge badge-ghost badge-sm text-warning">Key {metadata!.trackKey}</span>
+      {/if}
+    </div>
+  </div>
+
+  <div
+    data-testid="player-box"
+    class="flex min-w-18 flex-col items-center rounded-md border-2 px-3.5 py-1.5 font-mono {boxColor}"
+  >
+    <span class="text-[9px] tracking-widest uppercase opacity-70">Player</span>
+    <span class="text-[32px] leading-none font-bold">{playerNumber}</span>
+  </div>
+</div>

--- a/src/components/player-status/PlayerStatusBar.svelte
+++ b/src/components/player-status/PlayerStatusBar.svelte
@@ -18,11 +18,13 @@
     if (!metricsOk || metrics?.bpm === undefined) return "—";
     return (metrics.bpm / 100).toFixed(2);
   });
+  // pitchBend は node-tcnet 側で 100 倍スケールの Int16 として読まれている。
+  // 既存 MetricsView / CardsLayout と合わせて /100 した % 値に変換する。
   let pitchText = $derived.by(() => {
     if (!metricsOk || metrics?.pitchBend === undefined) return "—";
-    const p = metrics.pitchBend;
-    const sign = p > 0 ? "+" : p < 0 ? "" : "+";
-    return `${sign}${p.toFixed(2)}%`;
+    const percent = metrics.pitchBend / 100;
+    const sign = percent > 0 ? "+" : "";
+    return `${sign}${percent.toFixed(2)}%`;
   });
   let isMaster = $derived(metricsOk && metrics?.syncMaster === 1);
   let beatIndex = $derived(

--- a/src/components/player-status/PlayerStatusBar.svelte
+++ b/src/components/player-status/PlayerStatusBar.svelte
@@ -1,0 +1,95 @@
+<script lang="ts">
+  import type { LayerInfo, MetricsData, TimeInfo } from "$lib/types.js";
+  import { formatPlayerTime } from "$lib/player-status/time-format.js";
+  import { derivePlaybackPosition } from "$lib/player-status/playback-position.js";
+  import { isMetricsConsistent } from "$lib/player-status/track-consistency.js";
+
+  interface Props {
+    layer: LayerInfo;
+    time: TimeInfo | null;
+    metrics: MetricsData | null;
+  }
+  let { layer, time, metrics }: Props = $props();
+
+  let metricsOk = $derived(isMetricsConsistent(layer, metrics));
+  let position = $derived(derivePlaybackPosition(time, metricsOk ? metrics : null));
+  let onAir = $derived(time?.onAir === 1);
+  let bpmText = $derived.by(() => {
+    if (!metricsOk || metrics?.bpm === undefined) return "—";
+    return (metrics.bpm / 100).toFixed(2);
+  });
+  let pitchText = $derived.by(() => {
+    if (!metricsOk || metrics?.pitchBend === undefined) return "—";
+    const p = metrics.pitchBend;
+    const sign = p > 0 ? "+" : p < 0 ? "" : "+";
+    return `${sign}${p.toFixed(2)}%`;
+  });
+  let isMaster = $derived(metricsOk && metrics?.syncMaster === 1);
+  let beatIndex = $derived(
+    metricsOk && metrics?.beatMarker !== undefined
+      ? Math.min(Math.max((metrics.beatMarker - 1) | 0, 0), 3)
+      : -1,
+  );
+</script>
+
+<div class="grid grid-cols-[auto_1fr_auto_auto] items-center gap-5 border-y border-base-content/20 p-3.5 px-5">
+  {#if onAir}
+    <div class="rounded-sm border-2 border-error px-3 py-1 font-mono text-[11px] font-bold tracking-widest text-error">
+      ON AIR
+    </div>
+  {:else}
+    <div class="
+      rounded-sm border-2 border-base-content/40 px-3 py-1 font-mono text-[11px] font-bold tracking-widest
+      text-base-content/40
+    ">
+      OFF AIR
+    </div>
+  {/if}
+
+  <div class="flex items-baseline gap-6 font-mono">
+    <div>
+      <span class="block text-[9px] tracking-widest text-base-content/40 uppercase">Time</span>
+      <span class="text-[26px] leading-none font-semibold text-base-content">
+        {position.placeholder ? "--:--:--.-" : formatPlayerTime(position.clampedElapsedMs)}
+      </span>
+    </div>
+    <div>
+      <span class="block text-[9px] tracking-widest text-base-content/40 uppercase">Remain</span>
+      <span class="text-[26px] leading-none font-medium" style:color="#f7c8d4">
+        {position.placeholder ? "--:--:--.-" : formatPlayerTime(position.remainMs)}
+      </span>
+    </div>
+  </div>
+
+  <div class="text-right font-mono">
+    <span class="block text-[9px] tracking-widest text-base-content/40 uppercase">Tempo</span>
+    <div class="text-[24px] leading-[1.1] font-semibold text-base-content">{bpmText}</div>
+    <div class="text-[18px] leading-[1.1] text-warning">{pitchText}</div>
+  </div>
+
+  <div class="flex flex-col items-end gap-1.5">
+    <div class="flex gap-1.5">
+      {#if isMaster}
+        <span class="
+          rounded-sm bg-[#ff9e64] px-2.5 py-0.5 font-mono text-[10px] font-bold tracking-widest text-base-100
+        ">MASTER</span>
+      {:else}
+        <span class="
+          rounded-sm border border-base-content/40 px-2 py-0.5 font-mono text-[10px] font-bold tracking-widest
+          text-base-content/40
+        ">MASTER</span>
+      {/if}
+    </div>
+    <div class="flex gap-[3px]">
+      {#each [0, 1, 2, 3] as i}
+        <div
+          class="h-1 w-3.5 rounded-sm"
+          class:bg-accent={beatIndex === i}
+          class:shadow-[0_0_4px_rgba(158,206,106,0.5)]={beatIndex === i}
+          class:bg-base-content={beatIndex !== i}
+          class:opacity-20={beatIndex !== i}
+        ></div>
+      {/each}
+    </div>
+  </div>
+</div>

--- a/src/components/player-status/PlayerStatusLayout.svelte
+++ b/src/components/player-status/PlayerStatusLayout.svelte
@@ -1,0 +1,116 @@
+<script lang="ts">
+  import { dndzone, type DndEvent } from "svelte-dnd-action";
+  import { store } from "$lib/stores.svelte.js";
+  import type { Arrangement } from "$lib/types.js";
+  import { mergeDraggedOrder, pickActive } from "$lib/player-status/ordering.js";
+  import PlayerCard from "./PlayerCard.svelte";
+  import PlayerToolbar from "./PlayerToolbar.svelte";
+
+  type CardItem = { id: string; layerIndex: number };
+
+  // L1-L4 (index 0-3) のうち status !== "IDLE" の index を集める
+  let activeIndexes = $derived(
+    new Set(
+      store.layers
+        .slice(0, 4)
+        .map((l, i) => (l.status !== "IDLE" ? i : -1))
+        .filter((i) => i >= 0),
+    ),
+  );
+
+  let orderedActive = $derived(pickActive(store.playerStatusOrder, activeIndexes));
+
+  // svelte-dnd-action は items を書き換え可能な state として要求するため、
+  // $derived で読み取り専用値にせず $state + $effect で store から反映する
+  let items = $state<CardItem[]>([]);
+  $effect(() => {
+    items = orderedActive.map((i) => ({ id: `player-${i}`, layerIndex: i }));
+  });
+
+  function onConsider(e: CustomEvent<DndEvent<CardItem>>) {
+    items = e.detail.items;
+  }
+
+  function onFinalize(e: CustomEvent<DndEvent<CardItem>>) {
+    const dragged = e.detail.items.map((it) => it.layerIndex);
+    const merged = mergeDraggedOrder(store.playerStatusOrder, activeIndexes, dragged);
+    store.playerStatusOrder = merged;
+    try {
+      localStorage.setItem("playerStatusOrder", JSON.stringify(merged));
+    } catch {
+      // localStorage 失敗は握り潰して動作継続する
+    }
+    items = e.detail.items;
+  }
+
+  function arrangeClass(a: Arrangement, count: number): string {
+    if (a === "row") return "flex flex-row gap-5";
+    if (a === "grid" && count >= 2) return "grid grid-cols-2 gap-5";
+    return "flex flex-col gap-5";
+  }
+
+  // grid 3枚時のみ 3枚目を横2列に伸ばしてバランスを取る
+  function itemSpanClass(a: Arrangement, count: number, idx: number): string {
+    return a === "grid" && count === 3 && idx === 2 ? "col-span-2" : "";
+  }
+
+  function onArrangeChange(a: Arrangement) {
+    store.playerStatusArrange = a;
+    try {
+      localStorage.setItem("playerStatusArrange", a);
+    } catch {
+      // noop
+    }
+  }
+
+  function onZoomChange(layerIndex: number, v: number) {
+    const next = [...store.playerStatusZoom];
+    next[layerIndex] = Math.min(Math.max(v, 1), 8);
+    store.playerStatusZoom = next;
+    try {
+      localStorage.setItem("playerStatusZoom", JSON.stringify(next));
+    } catch {
+      // noop
+    }
+  }
+</script>
+
+<div class="min-h-screen bg-base-300 p-5">
+  <PlayerToolbar arrangement={store.playerStatusArrange} onChange={onArrangeChange} />
+
+  {#if items.length === 0}
+    <div class="mt-20 flex flex-col items-center gap-2 text-base-content/40">
+      <p class="text-lg">No active players</p>
+      <p class="text-sm">Load a track on CDJ 1-4</p>
+    </div>
+  {:else}
+    <div
+      class={arrangeClass(store.playerStatusArrange, items.length)}
+      use:dndzone={{ items, flipDurationMs: 200, type: "player-status-cards" }}
+      onconsider={onConsider}
+      onfinalize={onFinalize}
+    >
+      {#each items as item, idx (item.id)}
+        {@const i = item.layerIndex}
+        <div class={itemSpanClass(store.playerStatusArrange, items.length, idx)}>
+          <PlayerCard
+            layer={store.layers[i]!}
+            layerIndex={i}
+            playerNumber={i + 1}
+            metadata={store.metadata[i] ?? null}
+            metrics={store.metrics[i] ?? null}
+            time={store.time[i] ?? null}
+            artwork={store.artwork[i] ?? null}
+            artworkFailed={store.artworkFailed[i] ?? false}
+            waveformBig={store.waveformBig[i] ?? null}
+            waveformSmall={store.waveformSmall[i] ?? null}
+            cues={store.cues[i] ?? null}
+            beatgrid={store.beatgrid[i] ?? null}
+            zoomScale={store.playerStatusZoom[i] ?? 2}
+            onZoomChange={(v) => onZoomChange(i, v)}
+          />
+        </div>
+      {/each}
+    </div>
+  {/if}
+</div>

--- a/src/components/player-status/PlayerToolbar.svelte
+++ b/src/components/player-status/PlayerToolbar.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+  import type { Arrangement } from "$lib/types.js";
+
+  interface Props {
+    arrangement: Arrangement;
+    onChange: (a: Arrangement) => void;
+  }
+  let { arrangement, onChange }: Props = $props();
+
+  const modes: { key: Arrangement; label: string }[] = [
+    { key: "stack", label: "Stack" },
+    { key: "row", label: "Row" },
+    { key: "grid", label: "Grid" },
+  ];
+</script>
+
+<div class="mb-4 flex items-center justify-between rounded-md border border-base-content/20 bg-base-100 p-3 px-4">
+  <div class="flex items-center gap-3">
+    <span class="text-[10px] tracking-widest text-base-content/40 uppercase">Arrange</span>
+    <div class="join">
+      {#each modes as mode}
+        <button
+          class="btn join-item btn-sm"
+          class:btn-primary={arrangement === mode.key}
+          class:btn-ghost={arrangement !== mode.key}
+          onclick={() => onChange(mode.key)}
+        >
+          {mode.label}
+        </button>
+      {/each}
+    </div>
+  </div>
+  <span class="text-[11px] text-base-content/40">Drag any card to reorder</span>
+</div>

--- a/src/components/player-status/WaveformCanvas.svelte
+++ b/src/components/player-status/WaveformCanvas.svelte
@@ -1,0 +1,146 @@
+<script lang="ts">
+  import type { BeatGridEntry, CuePoint, WaveformBar } from "$lib/types.js";
+  import { calcWindow, timeToX, ZOOM_MAX, ZOOM_MIN } from "$lib/player-status/waveform-canvas/draw-math.js";
+  import CueMarkerLayer from "./CueMarkerLayer.svelte";
+
+  interface Props {
+    bars: WaveformBar[] | null;
+    cues: CuePoint[] | null;
+    beatgrid: BeatGridEntry[] | null;
+    currentTimeMs: number;
+    trackLengthMs: number;
+    zoomScale: number;
+    onZoomChange: (v: number) => void;
+    height?: number;
+  }
+  let {
+    bars, cues, beatgrid, currentTimeMs, trackLengthMs, zoomScale, onZoomChange,
+    height = 80,
+  }: Props = $props();
+
+  // Svelte 5 の bind:this は $state でないと reactive にならない
+  let canvasEl = $state<HTMLCanvasElement | undefined>(undefined);
+  let canvasWidth = $state(800);
+  let win = $derived(calcWindow({ currentMs: currentTimeMs, trackLengthMs, zoomScale, canvasWidth }));
+
+  function draw() {
+    if (!canvasEl) return;
+    const ctx = canvasEl.getContext("2d");
+    if (!ctx) return;
+    ctx.clearRect(0, 0, canvasWidth, height);
+
+    if (!bars || bars.length === 0 || trackLengthMs <= 0) return;
+
+    const barDurationMs = trackLengthMs / bars.length;
+    const { windowLeft, windowMs } = win;
+    if (windowMs <= 0) return;
+
+    ctx.fillStyle = "rgba(0,0,0,0.25)";
+    ctx.fillRect(0, 0, canvasWidth, height);
+
+    const firstIdx = Math.max(0, Math.floor(windowLeft / barDurationMs));
+    const lastIdx = Math.min(bars.length - 1, Math.ceil((windowLeft + windowMs) / barDurationMs));
+    for (let i = firstIdx; i <= lastIdx; i++) {
+      const bar = bars[i]!;
+      const barStartMs = i * barDurationMs;
+      const x = timeToX(barStartMs, windowLeft, windowMs, canvasWidth);
+      const w = Math.max((barDurationMs / windowMs) * canvasWidth, 1);
+      const level = (bar.level / 255) * height;
+      ctx.globalAlpha = Math.max(bar.color / 255, 0.1);
+      ctx.fillStyle = "rgb(122,162,247)";
+      ctx.fillRect(x, height - level, w, level);
+    }
+    ctx.globalAlpha = 1;
+
+    if (beatgrid && beatgrid.length > 0) {
+      for (const b of beatgrid) {
+        if (b.timestampMs < windowLeft || b.timestampMs > windowLeft + windowMs) continue;
+        const x = timeToX(b.timestampMs, windowLeft, windowMs, canvasWidth);
+        if (b.beatType === 1) {
+          ctx.strokeStyle = "rgba(247,118,142,0.6)";
+          ctx.lineWidth = 1.5;
+        } else {
+          ctx.strokeStyle = "rgba(192,202,245,0.25)";
+          ctx.lineWidth = 1;
+        }
+        ctx.beginPath();
+        ctx.moveTo(x, 0);
+        ctx.lineTo(x, height);
+        ctx.stroke();
+      }
+    }
+
+    ctx.strokeStyle = "rgb(247,118,142)";
+    ctx.lineWidth = 2;
+    ctx.beginPath();
+    ctx.moveTo(win.cursorX, 0);
+    ctx.lineTo(win.cursorX, height);
+    ctx.stroke();
+  }
+
+  $effect(() => {
+    if (!canvasEl) return;
+    const ro = new ResizeObserver((entries) => {
+      for (const e of entries) {
+        canvasWidth = e.contentRect.width;
+        canvasEl!.width = canvasWidth * window.devicePixelRatio;
+        canvasEl!.height = height * window.devicePixelRatio;
+        const ctx = canvasEl!.getContext("2d");
+        ctx?.setTransform(window.devicePixelRatio, 0, 0, window.devicePixelRatio, 0, 0);
+      }
+    });
+    ro.observe(canvasEl);
+    return () => ro.disconnect();
+  });
+
+  $effect(() => {
+    void bars; void cues; void beatgrid; void zoomScale; void trackLengthMs;
+    draw();
+  });
+
+  $effect(() => {
+    let handle: number;
+    const tick = () => {
+      draw();
+      handle = requestAnimationFrame(tick);
+    };
+    handle = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(handle);
+  });
+</script>
+
+<div class="px-5 pb-3">
+  <div class="mb-1 flex items-center justify-between gap-4">
+    <span class="text-[9px] tracking-widest text-base-content/40 uppercase">Zoom</span>
+    <div class="flex items-center gap-2 font-mono">
+      <span class="text-[9px] tracking-widest text-base-content/40 uppercase">Scale</span>
+      <input
+        type="range"
+        min={ZOOM_MIN}
+        max={ZOOM_MAX}
+        step="0.5"
+        value={zoomScale}
+        oninput={(e) => onZoomChange(Number(e.currentTarget.value))}
+        onpointerdown={(e) => e.stopPropagation()}
+        ontouchstart={(e) => e.stopPropagation()}
+        class="range w-36 range-primary range-xs"
+      />
+      <span class="w-8 text-right text-[11px] text-base-content">{zoomScale.toFixed(1)}×</span>
+    </div>
+  </div>
+
+  <CueMarkerLayer
+    {cues}
+    {trackLengthMs}
+    windowLeftMs={win.windowLeft}
+    windowMs={win.windowMs}
+  />
+
+  {#if bars && bars.length > 0 && trackLengthMs > 0}
+    <canvas bind:this={canvasEl} class="block w-full rounded-sm" style:height="{height}px"></canvas>
+  {:else}
+    <div class="flex items-center justify-center rounded-sm bg-base-100 text-[11px] text-base-content/40" style:height="{height}px">
+      No waveform data
+    </div>
+  {/if}
+</div>

--- a/src/components/player-status/WaveformCanvas.svelte
+++ b/src/components/player-status/WaveformCanvas.svelte
@@ -93,12 +93,12 @@
     return () => ro.disconnect();
   });
 
+  // 描画ループは RAF 1本に集約する。
+  // props (bars/cues/beatgrid/zoomScale/trackLengthMs/currentTimeMs) の変化は
+  // draw() 内で参照するため、Svelte のリアクティビティにより $effect が再実行され
+  // 新しい tick が開始される (古い tick は cleanup で cancel される)。
   $effect(() => {
-    void bars; void cues; void beatgrid; void zoomScale; void trackLengthMs;
-    draw();
-  });
-
-  $effect(() => {
+    void bars; void cues; void beatgrid; void zoomScale; void trackLengthMs; void currentTimeMs;
     let handle: number;
     const tick = () => {
       draw();

--- a/src/lib/message-handlers.ts
+++ b/src/lib/message-handlers.ts
@@ -123,7 +123,9 @@ export function createHandlers(store: MessageHandlerStore): HandlerMap {
     },
     "layer-reset": (msg) => {
       const i = msg.layer;
-      // metadataはクリアしない (新データで上書きされるまで前曲を表示し、レイアウトの崩れを防ぐ)
+      // metadataは保持 (trackIDで整合性チェックしてUI側でフィルタ)
+      store.metrics[i] = null;
+      store.time[i] = null;
       store.artwork[i] = null;
       store.artworkFailed[i] = false;
       store.cues[i] = null;

--- a/src/lib/player-status/ordering.ts
+++ b/src/lib/player-status/ordering.ts
@@ -1,0 +1,64 @@
+/**
+ * playerStatusOrder は常に [0, 1, 2, 3] の完全な permutation を持つ。
+ * L1-L4 (index 0-3) に対応する。
+ */
+export const DEFAULT_ORDER: number[] = [0, 1, 2, 3];
+const ORDER_LENGTH = 4;
+
+/**
+ * 配列が [0..3] の完全な permutation かを判定する。
+ */
+export function isValidOrder(order: readonly number[]): boolean {
+  if (!Array.isArray(order) || order.length !== ORDER_LENGTH) return false;
+  const seen = new Set<number>();
+  for (const v of order) {
+    if (!Number.isInteger(v) || v < 0 || v >= ORDER_LENGTH) return false;
+    if (seen.has(v)) return false;
+    seen.add(v);
+  }
+  return true;
+}
+
+/**
+ * 不正な order を検出したら DEFAULT_ORDER に復元する。
+ */
+export function normalizeOrder(order: readonly number[]): number[] {
+  return isValidOrder(order) ? [...order] : [...DEFAULT_ORDER];
+}
+
+/**
+ * order を走査し、activeIndexes に含まれる要素のみを順序保持で抽出する。
+ */
+export function pickActive(order: readonly number[], activeIndexes: ReadonlySet<number>): number[] {
+  return order.filter((i) => activeIndexes.has(i));
+}
+
+/**
+ * DnDで並び替えられた active subset を、完全な order に merge し直す。
+ * inactive 位置は不変。不正入力の場合は prevOrder を維持する。
+ */
+export function mergeDraggedOrder(
+  prevOrder: readonly number[],
+  activeIndexes: ReadonlySet<number>,
+  draggedActive: readonly number[],
+): number[] {
+  if (!isValidOrder(prevOrder)) return [...DEFAULT_ORDER];
+
+  const activePositions: number[] = [];
+  for (let i = 0; i < prevOrder.length; i++) {
+    if (activeIndexes.has(prevOrder[i]!)) activePositions.push(i);
+  }
+
+  if (activePositions.length !== draggedActive.length) return [...prevOrder];
+  const draggedSet = new Set(draggedActive);
+  if (draggedSet.size !== draggedActive.length) return [...prevOrder];
+  for (const v of draggedActive) {
+    if (!activeIndexes.has(v)) return [...prevOrder];
+  }
+
+  const newOrder = [...prevOrder];
+  for (let i = 0; i < activePositions.length; i++) {
+    newOrder[activePositions[i]!] = draggedActive[i]!;
+  }
+  return isValidOrder(newOrder) ? newOrder : [...prevOrder];
+}

--- a/src/lib/player-status/playback-position.ts
+++ b/src/lib/player-status/playback-position.ts
@@ -1,0 +1,45 @@
+import type { MetricsData, TimeInfo } from "../types.js";
+
+export type PlaybackPosition = {
+  placeholder: boolean;
+  elapsedMs: number;
+  clampedElapsedMs: number;
+  trackLengthMs: number;
+  remainMs: number;
+};
+
+const PLACEHOLDER: PlaybackPosition = {
+  placeholder: true,
+  elapsedMs: 0,
+  clampedElapsedMs: 0,
+  trackLengthMs: 0,
+  remainMs: 0,
+};
+
+/**
+ * 再生位置コントラクトに従って、時刻依存UIの値を導出する。
+ * SSoTは time.currentTimeMillis。metrics.currentPositionは使わない。
+ * MetricsData はすべて optional のため、undefined は placeholder として扱う。
+ */
+export function derivePlaybackPosition(
+  time: TimeInfo | null,
+  metrics: MetricsData | null,
+): PlaybackPosition {
+  if (!time || !metrics) return PLACEHOLDER;
+  const trackLengthMs = metrics.trackLength;
+  if (trackLengthMs === undefined || !Number.isFinite(trackLengthMs) || trackLengthMs <= 0) {
+    return PLACEHOLDER;
+  }
+
+  const elapsedMs = time.currentTimeMillis ?? 0;
+  const clampedElapsedMs = Math.min(Math.max(elapsedMs, 0), trackLengthMs);
+  const remainMs = trackLengthMs - clampedElapsedMs;
+
+  return {
+    placeholder: false,
+    elapsedMs,
+    clampedElapsedMs,
+    trackLengthMs,
+    remainMs,
+  };
+}

--- a/src/lib/player-status/time-format.ts
+++ b/src/lib/player-status/time-format.ts
@@ -1,0 +1,19 @@
+/**
+ * ミリ秒をMM:SS:FF.F形式に変換する
+ * - 1フレーム = 1/75秒
+ * - フレーム小数は 0 または 5 (0.5フレーム刻み)
+ * - 100分以上は分の桁を3桁ゼロ埋め
+ * - 負値・非数値・Infinityはプレースホルダを返す
+ */
+export function formatPlayerTime(ms: number): string {
+  if (!Number.isFinite(ms) || ms < 0) return "--:--:--.-";
+
+  const m = Math.floor(ms / 60_000);
+  const s = Math.floor((ms % 60_000) / 1000);
+  const totalFrames = (ms % 1000) / (1000 / 75);
+  const ff = Math.floor(totalFrames);
+  const fHalf = totalFrames - ff >= 0.5 ? 5 : 0;
+
+  const mPad = m >= 100 ? String(m).padStart(3, "0") : String(m).padStart(2, "0");
+  return `${mPad}:${String(s).padStart(2, "0")}:${String(ff).padStart(2, "0")}.${fHalf}`;
+}

--- a/src/lib/player-status/track-consistency.ts
+++ b/src/lib/player-status/track-consistency.ts
@@ -1,0 +1,19 @@
+import type { LayerInfo, MetadataData, MetricsData } from "../types.js";
+
+/**
+ * metadata[i] が layers[i] の現行トラックと一致するかを判定する。
+ * null の場合は false (整合性不明として扱う)。
+ */
+export function isMetadataConsistent(layer: LayerInfo, metadata: MetadataData | null): boolean {
+  if (!metadata) return false;
+  return metadata.trackID === layer.trackID;
+}
+
+/**
+ * metrics[i] が layers[i] の現行トラックと一致するかを判定する。
+ * null の場合は false。
+ */
+export function isMetricsConsistent(layer: LayerInfo, metrics: MetricsData | null): boolean {
+  if (!metrics) return false;
+  return metrics.trackID === layer.trackID;
+}

--- a/src/lib/player-status/waveform-canvas/draw-math.ts
+++ b/src/lib/player-status/waveform-canvas/draw-math.ts
@@ -1,0 +1,60 @@
+export type WindowParams = {
+  currentMs: number;
+  trackLengthMs: number;
+  zoomScale: number;
+  canvasWidth: number;
+};
+
+export type WindowResult = {
+  windowLeft: number;
+  windowMs: number;
+  cursorX: number;
+};
+
+export const ZOOM_MIN = 1;
+export const ZOOM_MAX = 8;
+export const CURSOR_ANCHOR_RATIO = 0.25;
+
+function clamp(v: number, min: number, max: number): number {
+  return Math.min(Math.max(v, min), max);
+}
+
+/**
+ * ズーム波形の表示範囲とカーソルX座標を計算する。
+ * 通常時はカーソル左25%固定、曲頭・曲末ではwindowLeftをclampする。
+ */
+export function calcWindow(p: WindowParams): WindowResult {
+  if (p.trackLengthMs <= 0) {
+    return { windowLeft: 0, windowMs: 0, cursorX: 0 };
+  }
+  const zoom = clamp(p.zoomScale, ZOOM_MIN, ZOOM_MAX);
+  const windowMs = p.trackLengthMs / zoom;
+  const anchor = windowMs * CURSOR_ANCHOR_RATIO;
+  const current = clamp(p.currentMs, 0, p.trackLengthMs);
+
+  let windowLeft: number;
+  if (current < anchor) {
+    windowLeft = 0;
+  } else if (current > p.trackLengthMs - (windowMs - anchor)) {
+    windowLeft = p.trackLengthMs - windowMs;
+  } else {
+    windowLeft = current - anchor;
+  }
+
+  const cursorX = ((current - windowLeft) / windowMs) * p.canvasWidth;
+  return { windowLeft, windowMs, cursorX };
+}
+
+/**
+ * 時刻をキャンバス上のX座標に変換する。
+ * 画面外でも値を返すので、呼び出し側でクリップ判定する。
+ */
+export function timeToX(
+  timeMs: number,
+  windowLeft: number,
+  windowMs: number,
+  canvasWidth: number,
+): number {
+  if (windowMs <= 0) return 0;
+  return ((timeMs - windowLeft) / windowMs) * canvasWidth;
+}

--- a/src/lib/stores.svelte.ts
+++ b/src/lib/stores.svelte.ts
@@ -10,10 +10,12 @@ import type {
   PacketLogEntry,
   BeatGridEntry,
   AuthState,
+  Arrangement,
 } from "./types.js";
 import { getLocalStorageValue } from "./storage.js";
+import { normalizeOrder } from "./player-status/ordering.js";
 
-export type LayoutMode = "cards" | "detail" | "table";
+export type LayoutMode = "cards" | "detail" | "table" | "player-status";
 
 export type Theme = "tokyo-night" | "tokyo-night-storm" | "tokyo-night-light";
 
@@ -39,7 +41,7 @@ export class ViewerStore {
   }
   layoutMode: LayoutMode = $state(
     getLocalStorageValue<LayoutMode>("layoutMode", "detail", (raw) => {
-      const valid: LayoutMode[] = ["cards", "detail", "table"];
+      const valid: LayoutMode[] = ["cards", "detail", "table", "player-status"];
       return valid.includes(raw as LayoutMode) ? (raw as LayoutMode) : "detail";
     }),
   );
@@ -56,6 +58,42 @@ export class ViewerStore {
     getLocalStorageValue<number>("packetLogHeight", 200, (raw) => {
       const parsed = Number(raw);
       return Number.isFinite(parsed) && parsed > 0 ? parsed : 200;
+    }),
+  );
+
+  playerStatusArrange: Arrangement = $state(
+    getLocalStorageValue<Arrangement>("playerStatusArrange", "stack", (raw) => {
+      const valid: Arrangement[] = ["stack", "row", "grid"];
+      return valid.includes(raw as Arrangement) ? (raw as Arrangement) : "stack";
+    }),
+  );
+
+  playerStatusOrder: number[] = $state(
+    getLocalStorageValue<number[]>("playerStatusOrder", [0, 1, 2, 3], (raw) => {
+      try {
+        const parsed = JSON.parse(raw) as unknown;
+        return normalizeOrder(parsed as number[]);
+      } catch {
+        return [0, 1, 2, 3];
+      }
+    }),
+  );
+
+  playerStatusZoom: number[] = $state(
+    getLocalStorageValue<number[]>("playerStatusZoom", [2, 2, 2, 2], (raw) => {
+      try {
+        const parsed = JSON.parse(raw) as unknown;
+        if (
+          Array.isArray(parsed) &&
+          parsed.length === 4 &&
+          parsed.every((v) => typeof v === "number")
+        ) {
+          return parsed.map((v) => Math.min(Math.max(v, 1), 8));
+        }
+      } catch {
+        // fallthrough
+      }
+      return [2, 2, 2, 2];
     }),
   );
 
@@ -97,6 +135,8 @@ export class ViewerStore {
   resetLayerData(): void {
     for (let i = 0; i < 8; i++) {
       this.metadata[i] = null;
+      this.metrics[i] = null;
+      this.time[i] = null;
       this.artwork[i] = null;
       this.artworkFailed[i] = false;
       this.cues[i] = null;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -72,6 +72,8 @@ export type PacketLogEntry = {
   summary: string;
 };
 
+export type Arrangement = "stack" | "row" | "grid";
+
 export const LAYER_NAMES = ["L1", "L2", "L3", "L4", "LA", "LB", "LM", "LC"] as const;
 
 export const STATUS_MAP: Record<number, LayerStatus> = {

--- a/tests/components/player-status/CueMarkerLayer.test.ts
+++ b/tests/components/player-status/CueMarkerLayer.test.ts
@@ -1,0 +1,51 @@
+// @vitest-environment jsdom
+import { describe, expect, test } from "vite-plus/test";
+import { render } from "@testing-library/svelte";
+import CueMarkerLayer from "../../../src/components/player-status/CueMarkerLayer.svelte";
+import type { CuePoint } from "../../../src/lib/types.js";
+
+const cue = (over: Partial<CuePoint> = {}): CuePoint => ({
+  index: 0,
+  type: 0,
+  inTime: 60_000,
+  outTime: 0,
+  color: { r: 122, g: 162, b: 247 },
+  ...over,
+});
+
+describe("CueMarkerLayer", () => {
+  test("hot cue は rgb 色の四角で描画される", () => {
+    const { container } = render(CueMarkerLayer, {
+      props: { cues: [cue({ type: 0 })], trackLengthMs: 180_000 },
+    });
+    const box = container.querySelector('[style*="background-color"]') as HTMLElement;
+    expect(box).toBeTruthy();
+    expect(box.getAttribute("style")).toContain("rgb(122, 162, 247)");
+  });
+  test("memory cue は赤逆三角 (border-top: error色)", () => {
+    const { container } = render(CueMarkerLayer, {
+      props: { cues: [cue({ type: 1 })], trackLengthMs: 180_000 },
+    });
+    const tri = container.querySelector('[style*="border-top"]') as HTMLElement;
+    expect(tri).toBeTruthy();
+    expect(tri.getAttribute("style")).toMatch(/border-top:\s*8px\s+solid\s+var\(--color-error\)/);
+  });
+  test("trackLengthMs=0 は描画しない", () => {
+    const { container } = render(CueMarkerLayer, {
+      props: { cues: [cue()], trackLengthMs: 0 },
+    });
+    expect(container.querySelector('[style*="background-color"]')).toBeNull();
+  });
+  test("windowMs 指定時は範囲外 cue を描画しない", () => {
+    const { container } = render(CueMarkerLayer, {
+      props: {
+        cues: [cue({ inTime: 30_000 }), cue({ inTime: 150_000 })],
+        trackLengthMs: 180_000,
+        windowLeftMs: 0,
+        windowMs: 60_000,
+      },
+    });
+    const boxes = container.querySelectorAll('[style*="background-color"]');
+    expect(boxes.length).toBe(1);
+  });
+});

--- a/tests/components/player-status/PlayerCard.test.ts
+++ b/tests/components/player-status/PlayerCard.test.ts
@@ -1,0 +1,34 @@
+// @vitest-environment jsdom
+import { describe, expect, test } from "vite-plus/test";
+import { render } from "@testing-library/svelte";
+import PlayerCard from "../../../src/components/player-status/PlayerCard.svelte";
+import type { LayerInfo } from "../../../src/lib/types.js";
+
+const layer: LayerInfo = { source: 0, status: "PLAYING", trackID: 42, name: "L1" };
+
+describe("PlayerCard", () => {
+  test("4セクション (Header/Zoom/Status/Full) が描画される", () => {
+    const { container } = render(PlayerCard, {
+      props: {
+        layer,
+        layerIndex: 0,
+        playerNumber: 1,
+        metadata: null,
+        metrics: null,
+        time: null,
+        artwork: null,
+        artworkFailed: false,
+        waveformBig: null,
+        waveformSmall: null,
+        cues: null,
+        beatgrid: null,
+        zoomScale: 2,
+        onZoomChange: () => {},
+      },
+    });
+    expect(container.querySelector('[data-testid="player-header"]')).toBeTruthy();
+    expect(container.querySelector('[data-testid="player-zoom"]')).toBeTruthy();
+    expect(container.querySelector('[data-testid="player-status-bar"]')).toBeTruthy();
+    expect(container.querySelector('[data-testid="player-full"]')).toBeTruthy();
+  });
+});

--- a/tests/components/player-status/PlayerHeader.test.ts
+++ b/tests/components/player-status/PlayerHeader.test.ts
@@ -1,0 +1,110 @@
+// @vitest-environment jsdom
+import { describe, expect, test } from "vite-plus/test";
+import { render } from "@testing-library/svelte";
+import PlayerHeader from "../../../src/components/player-status/PlayerHeader.svelte";
+import type { LayerInfo, MetadataData, MetricsData } from "../../../src/lib/types.js";
+
+const baseLayer: LayerInfo = { source: 0, status: "PLAYING", trackID: 42, name: "L1" };
+const baseMetadata = {
+  trackArtist: "Sembari",
+  trackTitle: "On Me",
+  trackKey: 7,
+  trackID: 42,
+} as unknown as MetadataData;
+const baseMetrics = {
+  state: 3,
+  syncMaster: 0,
+  beatMarker: 1,
+  trackLength: 334_000,
+  currentPosition: 0,
+  speed: 0,
+  beatNumber: 0,
+  bpm: 12600,
+  pitchBend: 0,
+  trackID: 42,
+} as unknown as MetricsData;
+
+describe("PlayerHeader", () => {
+  test("metadata整合時はTitle/Artistを表示する", () => {
+    const { getByText } = render(PlayerHeader, {
+      props: {
+        layer: baseLayer,
+        playerNumber: 2,
+        metadata: baseMetadata,
+        metrics: baseMetrics,
+        artwork: null,
+        artworkFailed: false,
+      },
+    });
+    expect(getByText("On Me")).toBeTruthy();
+    expect(getByText("Sembari")).toBeTruthy();
+  });
+  test("metadata.trackID不一致時はTitle/Artistを—で表示する", () => {
+    const { queryByText } = render(PlayerHeader, {
+      props: {
+        layer: { ...baseLayer, trackID: 99 },
+        playerNumber: 2,
+        metadata: baseMetadata,
+        metrics: baseMetrics,
+        artwork: null,
+        artworkFailed: false,
+      },
+    });
+    expect(queryByText("On Me")).toBeNull();
+    expect(queryByText("Sembari")).toBeNull();
+  });
+  test("metrics整合時にlength badgeが表示される", () => {
+    const { getByText } = render(PlayerHeader, {
+      props: {
+        layer: baseLayer,
+        playerNumber: 2,
+        metadata: baseMetadata,
+        metrics: baseMetrics,
+        artwork: null,
+        artworkFailed: false,
+      },
+    });
+    expect(getByText("05:34")).toBeTruthy();
+  });
+  test("metrics.trackID不一致時はlength badgeが非表示", () => {
+    const { queryByText } = render(PlayerHeader, {
+      props: {
+        layer: baseLayer,
+        playerNumber: 2,
+        metadata: baseMetadata,
+        metrics: { ...baseMetrics, trackID: 99 },
+        artwork: null,
+        artworkFailed: false,
+      },
+    });
+    expect(queryByText("05:34")).toBeNull();
+  });
+  test("PLAYING時はPLAYERボックスがaccent", () => {
+    const { container } = render(PlayerHeader, {
+      props: {
+        layer: baseLayer,
+        playerNumber: 2,
+        metadata: baseMetadata,
+        metrics: baseMetrics,
+        artwork: null,
+        artworkFailed: false,
+      },
+    });
+    const box = container.querySelector('[data-testid="player-box"]');
+    expect(box?.className).toContain("text-accent");
+  });
+  test("IDLE時はPLAYERボックスがmuted", () => {
+    const { container } = render(PlayerHeader, {
+      props: {
+        layer: { ...baseLayer, status: "IDLE" },
+        playerNumber: 2,
+        metadata: null,
+        metrics: null,
+        artwork: null,
+        artworkFailed: false,
+      },
+    });
+    const box = container.querySelector('[data-testid="player-box"]');
+    expect(box?.className).toContain("text-base-content/40");
+  });
+});

--- a/tests/components/player-status/PlayerStatusBar.test.ts
+++ b/tests/components/player-status/PlayerStatusBar.test.ts
@@ -1,0 +1,79 @@
+// @vitest-environment jsdom
+import { describe, expect, test } from "vite-plus/test";
+import { render } from "@testing-library/svelte";
+import PlayerStatusBar from "../../../src/components/player-status/PlayerStatusBar.svelte";
+import type { LayerInfo, MetricsData, TimeInfo } from "../../../src/lib/types.js";
+
+const layer: LayerInfo = { source: 0, status: "PLAYING", trackID: 42, name: "L1" };
+const time = (onAir: number, ms: number) =>
+  ({
+    type: 0,
+    currentTimeMillis: ms,
+    totalTimeMillis: 0,
+    remainingTimeMillis: 0,
+    onAir,
+  }) as unknown as TimeInfo;
+const metrics = (over: Partial<MetricsData> = {}): MetricsData => ({
+  state: 3,
+  syncMaster: 0,
+  beatMarker: 1,
+  trackLength: 180_000,
+  currentPosition: 0,
+  speed: 0,
+  beatNumber: 0,
+  bpm: 12600,
+  pitchBend: 0,
+  trackID: 42,
+  ...over,
+});
+const sparseMetrics: MetricsData = { trackID: 42 };
+
+describe("PlayerStatusBar", () => {
+  test("ON AIR バッジ (onAir=1) は赤枠赤文字", () => {
+    const { getByText } = render(PlayerStatusBar, {
+      props: { layer, time: time(1, 0), metrics: metrics() },
+    });
+    const badge = getByText("ON AIR");
+    expect(badge.className).toContain("text-error");
+  });
+  test("OFF AIR (onAir=0) はmuted表示", () => {
+    const { getByText } = render(PlayerStatusBar, {
+      props: { layer, time: time(0, 0), metrics: metrics() },
+    });
+    expect(getByText("OFF AIR")).toBeTruthy();
+  });
+  test("Time/Remain を MM:SS:FF.F で表示", () => {
+    const { getByText } = render(PlayerStatusBar, {
+      props: { layer, time: time(1, 30_000), metrics: metrics({ trackLength: 180_000 }) },
+    });
+    expect(getByText("00:30:00.0")).toBeTruthy();
+    expect(getByText("02:30:00.0")).toBeTruthy();
+  });
+  test("metrics=nullでTime/Remain placeholderを表示", () => {
+    const { getAllByText } = render(PlayerStatusBar, {
+      props: { layer, time: time(1, 30_000), metrics: null },
+    });
+    expect(getAllByText("--:--:--.-").length).toBeGreaterThanOrEqual(2);
+  });
+  test("metrics.trackID不一致でBPM/Pitch/Time placeholder", () => {
+    const { getAllByText, queryByText } = render(PlayerStatusBar, {
+      props: { layer, time: time(1, 30_000), metrics: metrics({ trackID: 99 }) },
+    });
+    expect(getAllByText("--:--:--.-").length).toBeGreaterThanOrEqual(2);
+    expect(queryByText("126.00")).toBeNull();
+  });
+  test("MASTER バッジ (syncMaster=1) 点灯", () => {
+    const { getByText } = render(PlayerStatusBar, {
+      props: { layer, time: time(1, 0), metrics: metrics({ syncMaster: 1 }) },
+    });
+    const badge = getByText("MASTER");
+    expect(badge.className).not.toContain("border-base-content/40");
+  });
+  test("sparseMetrics (bpm/pitchBend未定義) でBPM/Pitch placeholder", () => {
+    const { getAllByText, queryByText } = render(PlayerStatusBar, {
+      props: { layer, time: time(1, 30_000), metrics: sparseMetrics },
+    });
+    expect(getAllByText("—").length).toBeGreaterThanOrEqual(2);
+    expect(queryByText("126.00")).toBeNull();
+  });
+});

--- a/tests/components/player-status/PlayerStatusBar.test.ts
+++ b/tests/components/player-status/PlayerStatusBar.test.ts
@@ -76,4 +76,22 @@ describe("PlayerStatusBar", () => {
     expect(getAllByText("—").length).toBeGreaterThanOrEqual(2);
     expect(queryByText("126.00")).toBeNull();
   });
+  test("Pitch (pitchBend=123、100倍スケール) を +1.23% で表示", () => {
+    const { getByText } = render(PlayerStatusBar, {
+      props: { layer, time: time(1, 0), metrics: metrics({ pitchBend: 123 }) },
+    });
+    expect(getByText("+1.23%")).toBeTruthy();
+  });
+  test("Pitch (pitchBend=-123) は -1.23% で表示する (符号は toFixed 由来)", () => {
+    const { getByText } = render(PlayerStatusBar, {
+      props: { layer, time: time(1, 0), metrics: metrics({ pitchBend: -123 }) },
+    });
+    expect(getByText("-1.23%")).toBeTruthy();
+  });
+  test("Pitch (pitchBend=0) は 0.00% で表示する (符号なし)", () => {
+    const { getByText } = render(PlayerStatusBar, {
+      props: { layer, time: time(1, 0), metrics: metrics({ pitchBend: 0 }) },
+    });
+    expect(getByText("0.00%")).toBeTruthy();
+  });
 });

--- a/tests/components/player-status/PlayerStatusLayout.test.ts
+++ b/tests/components/player-status/PlayerStatusLayout.test.ts
@@ -1,0 +1,112 @@
+// @vitest-environment jsdom
+import { beforeAll, describe, expect, test } from "vite-plus/test";
+import { render } from "@testing-library/svelte";
+import PlayerStatusLayout from "../../../src/components/player-status/PlayerStatusLayout.svelte";
+import { store } from "../../../src/lib/stores.svelte.js";
+import { mergeDraggedOrder } from "../../../src/lib/player-status/ordering.js";
+
+// jsdom で未定義のブラウザAPIを補う (WaveformCanvas が ResizeObserver を使うため)
+beforeAll(() => {
+  if (!("ResizeObserver" in globalThis)) {
+    (globalThis as unknown as { ResizeObserver: unknown }).ResizeObserver = class {
+      observe(): void {}
+      unobserve(): void {}
+      disconnect(): void {}
+    };
+  }
+});
+
+function resetStore() {
+  for (let i = 0; i < 8; i++) {
+    store.layers[i] = { source: 0, status: "IDLE", trackID: 0, name: `L${i + 1}` };
+    store.metadata[i] = null;
+    store.metrics[i] = null;
+    store.time[i] = null;
+    store.waveformSmall[i] = null;
+    store.waveformBig[i] = null;
+    store.cues[i] = null;
+    store.beatgrid[i] = null;
+    store.artwork[i] = null;
+    store.artworkFailed[i] = false;
+  }
+  store.playerStatusOrder = [0, 1, 2, 3];
+  store.playerStatusArrange = "stack";
+  store.playerStatusZoom = [2, 2, 2, 2];
+}
+
+describe("PlayerStatusLayout", () => {
+  test("L1-L4全IDLEでエンプティステート", () => {
+    resetStore();
+    const { getByText } = render(PlayerStatusLayout);
+    expect(getByText("No active players")).toBeTruthy();
+  });
+
+  test("一部activeならそのカードのみ描画", () => {
+    resetStore();
+    store.layers[0] = { source: 0, status: "PLAYING", trackID: 42, name: "L1" };
+    store.layers[2] = { source: 0, status: "PLAYING", trackID: 43, name: "L3" };
+    const { queryAllByTestId } = render(PlayerStatusLayout);
+    expect(queryAllByTestId("player-card").length).toBe(2);
+  });
+
+  test("orderに従ってカードが並ぶ", () => {
+    resetStore();
+    store.layers[0] = { source: 0, status: "PLAYING", trackID: 42, name: "L1" };
+    store.layers[1] = { source: 0, status: "PLAYING", trackID: 43, name: "L2" };
+    store.playerStatusOrder = [1, 0, 2, 3];
+    const { queryAllByTestId } = render(PlayerStatusLayout);
+    const cards = queryAllByTestId("player-card");
+    expect(cards.length).toBe(2);
+    const numbers = cards.map(
+      (c) => c.querySelector('[data-testid="player-box"] span:last-child')?.textContent,
+    );
+    expect(numbers).toEqual(["2", "1"]);
+  });
+
+  test("Grid 2プレイヤー時、2列gridで横並び (col-span-2 なし)", () => {
+    resetStore();
+    store.layers[0] = { source: 0, status: "PLAYING", trackID: 42, name: "L1" };
+    store.layers[1] = { source: 0, status: "PLAYING", trackID: 43, name: "L2" };
+    store.playerStatusArrange = "grid";
+    const { container } = render(PlayerStatusLayout);
+    expect(container.querySelector(".grid-cols-2")).toBeTruthy();
+    expect(container.querySelectorAll(".col-span-2").length).toBe(0);
+  });
+
+  test("Grid 3プレイヤー時、3枚目のwrapperにcol-span-2が付く", () => {
+    resetStore();
+    store.layers[0] = { source: 0, status: "PLAYING", trackID: 42, name: "L1" };
+    store.layers[1] = { source: 0, status: "PLAYING", trackID: 43, name: "L2" };
+    store.layers[2] = { source: 0, status: "PLAYING", trackID: 44, name: "L3" };
+    store.playerStatusArrange = "grid";
+    const { container } = render(PlayerStatusLayout);
+    const spans = container.querySelectorAll(".col-span-2");
+    expect(spans.length).toBe(1);
+  });
+
+  test("Grid 4プレイヤー時、col-span-2 は付かない (2x2)", () => {
+    resetStore();
+    for (let i = 0; i < 4; i++) {
+      store.layers[i] = { source: 0, status: "PLAYING", trackID: 42 + i, name: `L${i + 1}` };
+    }
+    store.playerStatusArrange = "grid";
+    const { container } = render(PlayerStatusLayout);
+    const spans = container.querySelectorAll(".col-span-2");
+    expect(spans.length).toBe(0);
+  });
+
+  test("finalizeハンドラ相当: mergeDraggedOrderがstoreを更新する", () => {
+    resetStore();
+    store.layers[0] = { source: 0, status: "PLAYING", trackID: 42, name: "L1" };
+    store.layers[1] = { source: 0, status: "PLAYING", trackID: 43, name: "L2" };
+    store.layers[2] = { source: 0, status: "PLAYING", trackID: 44, name: "L3" };
+    store.playerStatusOrder = [0, 1, 2, 3];
+
+    const active = new Set([0, 1, 2]);
+    const dragged = [1, 0, 2];
+    const merged = mergeDraggedOrder(store.playerStatusOrder, active, dragged);
+    store.playerStatusOrder = merged;
+
+    expect(store.playerStatusOrder).toEqual([1, 0, 2, 3]);
+  });
+});

--- a/tests/components/player-status/PlayerToolbar.test.ts
+++ b/tests/components/player-status/PlayerToolbar.test.ts
@@ -1,0 +1,27 @@
+// @vitest-environment jsdom
+import { describe, expect, test, vi } from "vite-plus/test";
+import { fireEvent, render } from "@testing-library/svelte";
+import PlayerToolbar from "../../../src/components/player-status/PlayerToolbar.svelte";
+
+describe("PlayerToolbar", () => {
+  test("Stack/Row/Grid 3ボタンを表示", () => {
+    const { getByText } = render(PlayerToolbar, {
+      props: { arrangement: "stack", onChange: () => {} },
+    });
+    expect(getByText("Stack")).toBeTruthy();
+    expect(getByText("Row")).toBeTruthy();
+    expect(getByText("Grid")).toBeTruthy();
+  });
+  test("現在のarrangementボタンがaccent表示", () => {
+    const { getByText } = render(PlayerToolbar, {
+      props: { arrangement: "grid", onChange: () => {} },
+    });
+    expect(getByText("Grid").className).toContain("btn-primary");
+  });
+  test("ボタンクリックでonChangeが呼ばれる", async () => {
+    const onChange = vi.fn();
+    const { getByText } = render(PlayerToolbar, { props: { arrangement: "stack", onChange } });
+    await fireEvent.click(getByText("Row"));
+    expect(onChange).toHaveBeenCalledWith("row");
+  });
+});

--- a/tests/lib/message-handlers.test.ts
+++ b/tests/lib/message-handlers.test.ts
@@ -452,3 +452,84 @@ test("layer-reset: artworkFailedフラグをfalseにクリアする", () => {
   handlers["layer-reset"]({ type: "layer-reset", timestamp: 1000, layer: 1 });
   expect(store.artworkFailed[1]).toBe(false);
 });
+
+test("layer-reset: metricsとtimeもnullクリアする", () => {
+  const store = createMockStore();
+  const handlers = createHandlers(store);
+  handlers.metrics({
+    type: "metrics",
+    timestamp: 0,
+    layer: 2,
+    data: {
+      state: 3,
+      syncMaster: 0,
+      beatMarker: 1,
+      trackLength: 180_000,
+      currentPosition: 0,
+      speed: 0,
+      beatNumber: 0,
+      bpm: 12000,
+      pitchBend: 0,
+      trackID: 42,
+    },
+  });
+  handlers.time({
+    type: "time",
+    timestamp: 0,
+    data: {
+      layers: Array.from({ length: 8 }, (_, i) =>
+        i === 2
+          ? { currentTimeMillis: 30_000, totalTimeMillis: 0, beatMarker: 1, state: 3, onAir: 1 }
+          : { currentTimeMillis: 0, totalTimeMillis: 0, beatMarker: 0, state: 0, onAir: 0 },
+      ),
+      generalSMPTEMode: 0,
+    },
+  });
+  expect(store.metrics[2]?.trackID).toBe(42);
+  expect(store.time[2]?.currentTimeMillis).toBe(30_000);
+
+  handlers["layer-reset"]({ type: "layer-reset", timestamp: 0, layer: 2 });
+
+  expect(store.metrics[2]).toBeNull();
+  expect(store.time[2]).toBeNull();
+});
+
+test("race回帰: layer-reset後にmetrics先着・time未着でtimeはnullのまま", () => {
+  const store = createMockStore();
+  const handlers = createHandlers(store);
+
+  handlers.time({
+    type: "time",
+    timestamp: 0,
+    data: {
+      layers: Array.from({ length: 8 }, (_, i) =>
+        i === 2
+          ? { currentTimeMillis: 100_000, totalTimeMillis: 0, beatMarker: 1, state: 3, onAir: 1 }
+          : { currentTimeMillis: 0, totalTimeMillis: 0, beatMarker: 0, state: 0, onAir: 0 },
+      ),
+      generalSMPTEMode: 0,
+    },
+  });
+
+  handlers["layer-reset"]({ type: "layer-reset", timestamp: 0, layer: 2 });
+  handlers.metrics({
+    type: "metrics",
+    timestamp: 0,
+    layer: 2,
+    data: {
+      state: 3,
+      syncMaster: 0,
+      beatMarker: 1,
+      trackLength: 240_000,
+      currentPosition: 0,
+      speed: 0,
+      beatNumber: 0,
+      bpm: 13000,
+      pitchBend: 0,
+      trackID: 99,
+    },
+  });
+
+  expect(store.metrics[2]?.trackID).toBe(99);
+  expect(store.time[2]).toBeNull();
+});

--- a/tests/lib/player-status/ordering.test.ts
+++ b/tests/lib/player-status/ordering.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "vite-plus/test";
+import {
+  DEFAULT_ORDER,
+  isValidOrder,
+  normalizeOrder,
+  pickActive,
+  mergeDraggedOrder,
+} from "../../../src/lib/player-status/ordering.js";
+
+describe("isValidOrder", () => {
+  test("[0,1,2,3] は valid", () => {
+    expect(isValidOrder([0, 1, 2, 3])).toBe(true);
+  });
+  test("permutation [2,0,1,3] は valid", () => {
+    expect(isValidOrder([2, 0, 1, 3])).toBe(true);
+  });
+  test("長さ違いは invalid", () => {
+    expect(isValidOrder([0, 1, 2])).toBe(false);
+  });
+  test("重複は invalid", () => {
+    expect(isValidOrder([0, 0, 1, 2])).toBe(false);
+  });
+  test("範囲外は invalid", () => {
+    expect(isValidOrder([0, 1, 2, 4])).toBe(false);
+  });
+});
+
+describe("normalizeOrder", () => {
+  test("正常な入力はそのまま返す", () => {
+    expect(normalizeOrder([2, 0, 1, 3])).toEqual([2, 0, 1, 3]);
+  });
+  test("不正な入力はDEFAULT_ORDERに復元", () => {
+    expect(normalizeOrder([0, 0, 1, 2])).toEqual(DEFAULT_ORDER);
+    expect(normalizeOrder([])).toEqual(DEFAULT_ORDER);
+  });
+});
+
+describe("pickActive", () => {
+  test("activeのみをorder順で返す", () => {
+    expect(pickActive([2, 0, 1, 3], new Set([0, 1, 2]))).toEqual([2, 0, 1]);
+  });
+  test("全inactiveなら空配列", () => {
+    expect(pickActive([0, 1, 2, 3], new Set())).toEqual([]);
+  });
+  test("元の相対順序を保つ", () => {
+    expect(pickActive([3, 2, 1, 0], new Set([0, 2]))).toEqual([2, 0]);
+  });
+});
+
+describe("mergeDraggedOrder", () => {
+  test("active部分のみ並び替え、inactive位置は不変", () => {
+    const out = mergeDraggedOrder([0, 2, 1, 3], new Set([0, 1, 2]), [2, 0, 1]);
+    expect(out).toEqual([2, 0, 1, 3]);
+  });
+  test("inactive位置がprevOrderの中央にある場合", () => {
+    const out = mergeDraggedOrder([0, 2, 1, 3], new Set([0, 3]), [3, 0]);
+    expect(out).toEqual([3, 2, 1, 0]);
+  });
+  test("不正なdraggedActive長でprevOrderを維持", () => {
+    expect(mergeDraggedOrder([0, 1, 2, 3], new Set([0, 1]), [0, 1, 2])).toEqual([0, 1, 2, 3]);
+  });
+  test("不正なdraggedActive (重複) でprevOrderを維持", () => {
+    expect(mergeDraggedOrder([0, 1, 2, 3], new Set([0, 1, 2]), [0, 0, 1])).toEqual([0, 1, 2, 3]);
+  });
+});

--- a/tests/lib/player-status/playback-position.test.ts
+++ b/tests/lib/player-status/playback-position.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, test } from "vite-plus/test";
+import { derivePlaybackPosition } from "../../../src/lib/player-status/playback-position.js";
+import type { TimeInfo } from "../../../src/lib/types.js";
+import type { MetricsData } from "../../../src/lib/types.js";
+
+function time(currentTimeMillis: number, onAir = 1): TimeInfo {
+  return {
+    type: 0,
+    currentTimeMillis,
+    totalTimeMillis: 0,
+    remainingTimeMillis: 0,
+    onAir,
+  } as unknown as TimeInfo;
+}
+function metrics(trackLength: number, trackID = 1): MetricsData {
+  return {
+    state: 3,
+    syncMaster: 0,
+    beatMarker: 1,
+    trackLength,
+    currentPosition: 0,
+    speed: 0,
+    beatNumber: 0,
+    bpm: 12000,
+    pitchBend: 0,
+    trackID,
+  };
+}
+// sparse metrics: optional フィールドが欠けている現実的なパケット想定
+const sparseMetrics: MetricsData = { trackID: 1 };
+
+describe("derivePlaybackPosition", () => {
+  test("metrics.trackLength=undefinedはplaceholder", () => {
+    const r = derivePlaybackPosition(time(30_000), sparseMetrics);
+    expect(r.placeholder).toBe(true);
+  });
+
+  test("time/metrics揃った通常ケース", () => {
+    const r = derivePlaybackPosition(time(30_000), metrics(180_000));
+    expect(r.placeholder).toBe(false);
+    expect(r.elapsedMs).toBe(30_000);
+    expect(r.clampedElapsedMs).toBe(30_000);
+    expect(r.trackLengthMs).toBe(180_000);
+    expect(r.remainMs).toBe(150_000);
+  });
+  test("elapsedがtrackLengthを超過した場合はclamp", () => {
+    const r = derivePlaybackPosition(time(200_000), metrics(180_000));
+    expect(r.clampedElapsedMs).toBe(180_000);
+    expect(r.remainMs).toBe(0);
+  });
+  test("負のelapsedは0にclamp", () => {
+    const r = derivePlaybackPosition(time(-1000), metrics(180_000));
+    expect(r.clampedElapsedMs).toBe(0);
+    expect(r.remainMs).toBe(180_000);
+  });
+  test("time=nullはplaceholder", () => {
+    const r = derivePlaybackPosition(null, metrics(180_000));
+    expect(r.placeholder).toBe(true);
+  });
+  test("metrics=nullはplaceholder", () => {
+    const r = derivePlaybackPosition(time(30_000), null);
+    expect(r.placeholder).toBe(true);
+  });
+  test("trackLength=0はplaceholder", () => {
+    const r = derivePlaybackPosition(time(30_000), metrics(0));
+    expect(r.placeholder).toBe(true);
+  });
+  test("remainは常に非負", () => {
+    const r = derivePlaybackPosition(time(999_999), metrics(1000));
+    expect(r.remainMs).toBeGreaterThanOrEqual(0);
+  });
+});

--- a/tests/lib/player-status/time-format.test.ts
+++ b/tests/lib/player-status/time-format.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "vite-plus/test";
+import { formatPlayerTime } from "../../../src/lib/player-status/time-format.js";
+
+describe("formatPlayerTime", () => {
+  test("0msはゼロ埋め3要素で返す", () => {
+    expect(formatPlayerTime(0)).toBe("00:00:00.0");
+  });
+  test("通常値 (3分45秒 + 22フレーム + 0.5フレーム)", () => {
+    // 3*60000 + 45000 + (22 + 0.5) * (1000/75) = 225000 + 300 = 225300ms
+    const ms = 3 * 60000 + 45 * 1000 + Math.round(22.5 * (1000 / 75));
+    expect(formatPlayerTime(ms)).toBe("03:45:22.5");
+  });
+  test("フレーム小数は 0 か 5 のみに丸める", () => {
+    expect(formatPlayerTime(Math.round(0.3 * (1000 / 75)))).toBe("00:00:00.0");
+    expect(formatPlayerTime(Math.round(0.7 * (1000 / 75)))).toBe("00:00:00.5");
+  });
+  test("100分以上で分の桁が3桁 zero-pad", () => {
+    expect(formatPlayerTime(101 * 60_000)).toBe("101:00:00.0");
+  });
+  test("負値はplaceholder", () => {
+    expect(formatPlayerTime(-1)).toBe("--:--:--.-");
+  });
+  test("NaNはplaceholder", () => {
+    expect(formatPlayerTime(Number.NaN)).toBe("--:--:--.-");
+  });
+  test("Infinityはplaceholder", () => {
+    expect(formatPlayerTime(Number.POSITIVE_INFINITY)).toBe("--:--:--.-");
+  });
+});

--- a/tests/lib/player-status/track-consistency.test.ts
+++ b/tests/lib/player-status/track-consistency.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "vite-plus/test";
+import {
+  isMetadataConsistent,
+  isMetricsConsistent,
+} from "../../../src/lib/player-status/track-consistency.js";
+import type { LayerInfo, MetadataData, MetricsData } from "../../../src/lib/types.js";
+
+const layer = (trackID: number): LayerInfo => ({
+  source: 0,
+  status: "PLAYING",
+  trackID,
+  name: "L1",
+});
+const md = (trackID: number) =>
+  ({ trackArtist: "a", trackTitle: "t", trackKey: 0, trackID }) as unknown as MetadataData;
+const mt = (trackID: number) =>
+  ({
+    state: 3,
+    syncMaster: 0,
+    beatMarker: 1,
+    trackLength: 1,
+    currentPosition: 0,
+    speed: 0,
+    beatNumber: 0,
+    bpm: 0,
+    pitchBend: 0,
+    trackID,
+  }) as unknown as MetricsData;
+
+describe("isMetadataConsistent", () => {
+  test("trackID一致でtrue", () => {
+    expect(isMetadataConsistent(layer(42), md(42))).toBe(true);
+  });
+  test("trackID不一致でfalse", () => {
+    expect(isMetadataConsistent(layer(42), md(43))).toBe(false);
+  });
+  test("metadata=nullでfalse", () => {
+    expect(isMetadataConsistent(layer(42), null)).toBe(false);
+  });
+  test("layers.trackID=0 (IDLE) でもmetadataと一致すればtrue (placeholder側で別途IDLE除外)", () => {
+    expect(isMetadataConsistent(layer(0), md(0))).toBe(true);
+  });
+});
+
+describe("isMetricsConsistent", () => {
+  test("trackID一致でtrue", () => {
+    expect(isMetricsConsistent(layer(42), mt(42))).toBe(true);
+  });
+  test("trackID不一致でfalse", () => {
+    expect(isMetricsConsistent(layer(42), mt(43))).toBe(false);
+  });
+  test("metrics=nullでfalse", () => {
+    expect(isMetricsConsistent(layer(42), null)).toBe(false);
+  });
+});

--- a/tests/lib/player-status/waveform-canvas/draw-math.test.ts
+++ b/tests/lib/player-status/waveform-canvas/draw-math.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, test } from "vite-plus/test";
+import {
+  calcWindow,
+  timeToX,
+} from "../../../../src/lib/player-status/waveform-canvas/draw-math.js";
+
+describe("calcWindow", () => {
+  test("通常時: currentの左25%にカーソル", () => {
+    const w = calcWindow({
+      currentMs: 60_000,
+      trackLengthMs: 180_000,
+      zoomScale: 2,
+      canvasWidth: 400,
+    });
+    expect(w.windowMs).toBe(90_000);
+    expect(w.windowLeft).toBe(37_500);
+    expect(w.cursorX).toBe(100);
+  });
+  test("曲頭: windowLeftは0にclamp、カーソルは左端から右へ移動", () => {
+    const w = calcWindow({
+      currentMs: 20_000,
+      trackLengthMs: 360_000,
+      zoomScale: 2,
+      canvasWidth: 400,
+    });
+    expect(w.windowLeft).toBe(0);
+    expect(w.cursorX).toBeCloseTo((20_000 / 180_000) * 400);
+  });
+  test("曲末: windowLeftは曲末-windowMsにclamp、カーソルは右側へ", () => {
+    const w = calcWindow({
+      currentMs: 170_000,
+      trackLengthMs: 180_000,
+      zoomScale: 2,
+      canvasWidth: 400,
+    });
+    expect(w.windowLeft).toBe(180_000 - 90_000);
+    expect(w.cursorX).toBeCloseTo(((170_000 - 90_000) / 90_000) * 400);
+  });
+  test("zoomScale範囲外はclamp (1-8)", () => {
+    const w1 = calcWindow({
+      currentMs: 0,
+      trackLengthMs: 100_000,
+      zoomScale: 0.5,
+      canvasWidth: 400,
+    });
+    expect(w1.windowMs).toBe(100_000);
+    const w2 = calcWindow({
+      currentMs: 0,
+      trackLengthMs: 100_000,
+      zoomScale: 10,
+      canvasWidth: 400,
+    });
+    expect(w2.windowMs).toBe(100_000 / 8);
+  });
+  test("trackLength=0はwindowMs=0、cursorX=0", () => {
+    const w = calcWindow({ currentMs: 0, trackLengthMs: 0, zoomScale: 2, canvasWidth: 400 });
+    expect(w.windowMs).toBe(0);
+    expect(w.cursorX).toBe(0);
+  });
+});
+
+describe("timeToX", () => {
+  test("windowLeftに一致する時刻はx=0", () => {
+    expect(timeToX(37_500, 37_500, 90_000, 400)).toBe(0);
+  });
+  test("windowRightに一致する時刻はx=canvasWidth", () => {
+    expect(timeToX(127_500, 37_500, 90_000, 400)).toBe(400);
+  });
+  test("windowMs=0は常にx=0", () => {
+    expect(timeToX(100, 0, 0, 400)).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

- Deep-Symmetry/beat-link-trigger の Player Status を参考にした新規レイアウトモード (`"player-status"`) を追加し、L1-L4 のアクティブプレイヤーをカード単位で俯瞰表示する
- 拡大波形 (Canvas 2D スクロール追従 + ビートグリッド + Cue マーカー + 1x-8x ズームスライダー) / 全体波形 (既存 `WaveformSvg` を `cues` Prop で拡張) / ON AIR 赤枠・MASTER オレンジバッジ・Time/Remain `MM:SS:FF.F` / Stack・Row・Grid 配置切替 / svelte-dnd-action によるカード並び替え を実装する
- Race-safety として `layer-reset` ハンドラで `metrics`/`time` もクリアし、UI 側で `trackID` 整合性チェックを重ねる (再生位置は `time.currentTimeMillis` を SSoT として統一)

## Context

- 設計書: `docs/superpowers/specs/2026-04-13-player-status-layout-design.md` (Codex adversarial review 2 セット完了)
- 実装計画: `docs/superpowers/plans/2026-04-13-player-status-layout.md` (Codex adversarial review 2 セット完了)
- 実装: 18 コミット、TDD サイクルで各タスク単位に分割 (純粋ロジック → 既存拡張 → 新規コンポーネント → 統合)
- Final code review 指摘への対応コミット済み (pitch 100倍スケール修正、RAF 重複統合、drag handle 限定)

## Test plan

- [x] `vp check` pass (Oxfmt + Oxlint + TypeScript strict)
- [x] `vp test` pass (28 files / 304 tests)
- [x] `vp build` pass (dist 出力正常)
- [x] race 回帰テスト: `layer-reset` 後に metrics 先着 / time 未着で time が null のまま維持されること
- [ ] 実機動作確認 (本 PR マージ前にユーザーがブラウザで確認する想定):
  - [ ] CDJ 1-4 でのカード描画 (アートワーク / タイトル / アーティスト / メタ badge / Player No 枠)
  - [ ] ズーム波形のスクロール追従 / Zoom スライダー (1x-8x) / Cue マーカー / ビートグリッド
  - [ ] ON AIR / Time / Remain / BPM / Pitch (%) / MASTER バッジ / Beat バー表示
  - [ ] フル波形 + 現在位置カーソル + Cue マーカー
  - [ ] トラック切替時に旧データが新データと混ざらないこと
  - [ ] Stack / Row / Grid 配置トグル (3プレイヤー時の 2+1 / 4プレイヤー時の 2x2)
  - [ ] カードのドラッグ並び替え (ヘッダ部をドラッグ) と localStorage 永続化
  - [ ] 他レイアウト (Cards/Detail/Table) の既存動作に影響がないこと

## スコープ外 (将来拡張)

- 波形のカラフル化 (waveformBig の色情報をバー単位で反映)
- Loop 区間の波形上描画
- USB/SD メディアソース表示 (TCNet プロトコル未対応)
- ホットキューのコメント表示 (同上)
- SYNC バッジ (TCNet 仕様上、Slave/Sync の区別不可のため本 PR では廃止)